### PR TITLE
Auto detect circular

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,36 @@
 [![DOI](https://zenodo.org/badge/195021481.svg)](https://zenodo.org/badge/latestdoi/195021481)
 [![paper](https://img.shields.io/badge/paper-Bioinformatics-%23167da4)](https://doi.org/10.1093/bioinformatics/btae760)
 
+<details>
+<summary><strong>🔀 About This Fork</strong> <img alt="custom fork" src="https://img.shields.io/badge/fork-custom-blue?style=flat-square"></summary>
+
+This fork of [`MeSS`](https://github.com/metagenlab/MeSS) introduces a custom feature for enhanced support of circular contig detection from local multi-fasta files.
+
+### ✨ Key Additions
+
+- `--auto-detect-circular` CLI flag: Automatically detects circular contigs using naming conventions
+- Pattern-based classification:
+  - Names like `plasmid`, `chromosome`, or ending in `c` (e.g., `ptg123c`) are treated as circular
+  - Names ending in `l` (e.g., `ptg123l`) are explicitly treated as linear
+- Integrated into Snakemake pipeline
+  - The flag propagates through preflight, simulation, and `split_contigs.py`
+  - Backward-compatible with `rotate` values and FASTA-level annotations
+- Improved logic to apply rotation only when needed
+- Adjusts coverage simulation based on rotation for circular contigs
+
+### ⚙️ Intended Use
+
+This fork is intended for workflows that:
+- Simulate mixed circular and linear genomes
+- Need automatic topology detection without manual annotation
+- Follow consistent contig naming conventions
+
+Unless the `--auto-detect-circular` flag is set, the original behavior is preserved.
+
+> This fork is maintained independently and includes custom features not present in the upstream `MeSS` repository.
+
+</details>
+
 The Metagenomic Sequence Simulator (MeSS) is a [Snakemake](https://github.com/snakemake/snakemake) pipeline, implemented using [Snaketool](https://github.com/beardymcjohnface/Snaketool), for simulating illumina, Oxford Nanopore (ONT) and Pacific Bioscience (PacBio) shotgun metagenomic samples.
 
 ## :mag: Overview

--- a/mess/__main__.py
+++ b/mess/__main__.py
@@ -56,6 +56,7 @@ cmd_sim_options = (
             "--tech",
             "--bases",
             "--rotate",
+            "--auto-detect-circular",
             "--tool",
             "--error",
             "--mean-len",

--- a/mess/util.py
+++ b/mess/util.py
@@ -233,6 +233,13 @@ def sim_options(func):
             show_default=True,
         ),
         click.option(
+            "--auto-detect-circular",
+            help="Auto-detect circular contigs based on naming patterns",
+            is_flag=True,
+            default=False,
+            show_default=True,
+        ),
+        click.option(
             "--tech",
             help="Sequencing technology",
             type=click.Choice(["illumina", "pacbio", "nanopore"], case_sensitive=False),

--- a/mess/workflow/rules/preflight/functions.smk
+++ b/mess/workflow/rules/preflight/functions.smk
@@ -148,7 +148,7 @@ def is_circular():
     else:
         files = glob.glob(f"{INPUT}/*.tsv")
     df = pd.concat([pd.read_csv(file, sep="\t") for file in files])
-    if ROTATE > 1 or "rotate" in df.columns:
+    if ROTATE > 1 or "rotate" in df.columns or AUTO_DETECT_CIRCULAR:
         return True
     else:
         return False

--- a/mess/workflow/rules/processing/fastas.smk
+++ b/mess/workflow/rules/processing/fastas.smk
@@ -53,6 +53,7 @@ checkpoint split_contigs:
     params:
         circular=CIRCULAR,
         rotate=ROTATE,
+        auto_detect_circular=AUTO_DETECT_CIRCULAR,
     resources:
         mem_mb=config.resources.sml.mem,
         mem=str(config.resources.sml.mem) + "MB",
@@ -72,6 +73,7 @@ if CIRCULAR:
             ),
         params:
             lambda wildcards: get_value("random_start", wildcards),
+            rotate=lambda wildcards: get_value("rotate", wildcards),
         log:
             os.path.join(
                 dir.out.logs,
@@ -91,6 +93,11 @@ if CIRCULAR:
             containers.seqkit
         shell:
             """
-            seqkit restart -i {params} {input} | \\
-            seqkit replace -p .+ -r {wildcards.contig}_{wildcards.n} > {output}
+            if [ {params.rotate} -gt 1 ]; then
+                seqkit restart -i {params[0]} {input} | \
+                seqkit replace -p .+ -r {wildcards.contig}_{wildcards.n} > {output}
+            else
+                # For linear contigs, just rename without rotation
+                cat {input} | seqkit replace -p .+ -r {wildcards.contig}_{wildcards.n} > {output}
+            fi
             """

--- a/mess/workflow/scripts/split_contigs.py
+++ b/mess/workflow/scripts/split_contigs.py
@@ -3,6 +3,7 @@ import pandas as pd
 import os
 from itertools import chain
 import random
+import re
 
 
 def get_random_start(seed, contig_length, n):
@@ -37,8 +38,28 @@ cols = ["samplename", "fasta", "contig", "contig_length", "tax_id", "seed", "cov
 
 if snakemake.params.circular:
     cols += ["n", "random_start", "rotate"]
+
     if "rotate" not in df.columns:
         df.loc[:, "rotate"] = [snakemake.params.rotate] * len(df)
+
+    # Apply pattern-based rules if auto-detect is enabled
+    if hasattr(snakemake.params, 'auto_detect_circular') and snakemake.params.auto_detect_circular:
+        # Pattern for circular contigs (plasmid, chromosome, or ptg/utg ending with 'c')
+        circular_pattern = re.compile(r'(plasmid|chromosome|[up]tg\d+c)', re.IGNORECASE)
+        # Pattern for explicitly linear contigs
+        linear_pattern = re.compile(r'[up]tg\d+l', re.IGNORECASE)
+        
+        # Process all contigs
+        for idx, row in df.iterrows():
+            contig_name = row["contig"]
+            
+            # Force linear for anything with 'l' suffix pattern regardless of other settings
+            if linear_pattern.search(contig_name):
+                df.loc[idx, "rotate"] = 1
+            # Apply circular pattern only if not already matched as linear
+            elif not circular_pattern.search(contig_name):
+                df.loc[idx, "rotate"] = 1
+                
     df["random_start"] = df.apply(
         lambda row: get_random_start(row["seed"], row["contig_length"], row["rotate"]),
         axis=1,

--- a/mess/workflow/simulate.smk
+++ b/mess/workflow/simulate.smk
@@ -82,6 +82,7 @@ include: os.path.join("rules", "processing", "coverages.smk")
 # fasta processing options
 ROTATE = config.args.rotate
 CIRCULAR = is_circular()
+AUTO_DETECT_CIRCULAR = config.args.auto_detect_circular
 
 
 include: os.path.join("rules", "processing", "fastas.smk")


### PR DESCRIPTION
This pull request introduces a new feature to automatically detect circular contigs based on naming conventions in the `MeSS` pipeline. The changes include updates to the CLI, Snakemake pipeline, and associated scripts to support this feature.

Key changes include:

### New Feature Implementation:

* **README.md**: Added a section detailing the new `--auto-detect-circular` flag and its usage for circular contig detection.
* **CLI Update**: Introduced the `--auto-detect-circular` flag in the `mess/__main__.py` and `mess/util.py` files to enable the automatic detection of circular contigs. [[1]](diffhunk://#diff-ec2dbd8684dadc2698294f432dfb2b5379e4539a47df850da30f551288e8b04dR59) [[2]](diffhunk://#diff-8ce7e1df4e581f8762ec33f7685fa0d0caabab42ffda08058fc7cce408cd2927R235-R241)

### Pipeline Integration:

* **Preflight Check**: Modified the `is_circular` function in `mess/workflow/rules/preflight/functions.smk` to consider the `AUTO_DETECT_CIRCULAR` flag.
* **Processing Rules**: Updated the `split_contigs` checkpoint and related rules in `mess/workflow/rules/processing/fastas.smk` to handle the new flag and adjust contig processing logic accordingly. [[1]](diffhunk://#diff-a046d7dcb238dcf5bd67b2c40f88d81488f1fad8fad741337dbd32336d5d8ac8R56) [[2]](diffhunk://#diff-a046d7dcb238dcf5bd67b2c40f88d81488f1fad8fad741337dbd32336d5d8ac8R76) [[3]](diffhunk://#diff-a046d7dcb238dcf5bd67b2c40f88d81488f1fad8fad741337dbd32336d5d8ac8L94-R102)

### Script Enhancements:

* **Pattern-Based Detection**: Enhanced the `split_contigs.py` script to apply pattern-based classification for circular and linear contigs when the `--auto-detect-circular` flag is set. [[1]](diffhunk://#diff-3c438c91b24c974db72027512e90b0b4b4aa1df944868d4a17fd906acdee148dR6) [[2]](diffhunk://#diff-3c438c91b24c974db72027512e90b0b4b4aa1df944868d4a17fd906acdee148dR41-R62)
* **Configuration Update**: Added the `AUTO_DETECT_CIRCULAR` configuration in `mess/workflow/simulate.smk` to propagate the flag through the pipeline.