### PR TITLE
Fix variable logic steps for auto circular contig detection

### DIFF
--- a/mess/workflow/Snakefile
+++ b/mess/workflow/Snakefile
@@ -102,7 +102,8 @@ include: os.path.join("rules", "processing", "coverages.smk")
 
 # fasta processing options
 ROTATE = config.args.rotate
-CIRCULAR = is_circular()
+AUTO_DETECT_CIRCULAR = config.args.auto_detect_circular
+CIRCULAR = is_circular(AUTO_DETECT_CIRCULAR)
 
 
 include: os.path.join("rules", "processing", "fastas.smk")

--- a/mess/workflow/rules/preflight/functions.smk
+++ b/mess/workflow/rules/preflight/functions.smk
@@ -142,13 +142,13 @@ def get_asm_summary(wildcards):
     return table
 
 
-def is_circular():
+def is_circular(auto_detect_circular=False):
     if os.path.isfile(INPUT):
         files = [INPUT]
     else:
         files = glob.glob(f"{INPUT}/*.tsv")
     df = pd.concat([pd.read_csv(file, sep="\t") for file in files])
-    if ROTATE > 1 or "rotate" in df.columns or AUTO_DETECT_CIRCULAR:
+    if ROTATE > 1 or "rotate" in df.columns or auto_detect_circular:
         return True
     else:
         return False

--- a/mess/workflow/simulate.smk
+++ b/mess/workflow/simulate.smk
@@ -81,9 +81,8 @@ include: os.path.join("rules", "processing", "coverages.smk")
 
 # fasta processing options
 ROTATE = config.args.rotate
-CIRCULAR = is_circular()
 AUTO_DETECT_CIRCULAR = config.args.auto_detect_circular
-
+CIRCULAR = is_circular(AUTO_DETECT_CIRCULAR)
 
 include: os.path.join("rules", "processing", "fastas.smk")
 


### PR DESCRIPTION
This pull request fixes the error when running `mess run` or `mess test` (`name 'AUTO_DETECT_CIRCULAR' is not defined`). In these cases, the variable was used before it was defined, which happened later in the `simulate.smk` file. The most important changes include modifying the `is_circular` function to accept an optional parameter and updating the workflow files to use this new parameter.

Improvements to circularity detection logic:

* [`mess/workflow/rules/preflight/functions.smk`](diffhunk://#diff-2fb74b280ab953a496dbe3d22260bf176712f4143f4a3f9cbc16018cb32f1531L145-R151): Modified the `is_circular` function to accept an optional `auto_detect_circular` parameter.

Updates to workflow files:

* [`mess/workflow/Snakefile`](diffhunk://#diff-5d3945a242a0393f7494b5bcdee7eda54224917ce32e23204f9c49dce524e5faL105-R106), [`mess/workflow/simulate.smk`](diffhunk://#diff-67ffd902cfcc5bf68ab0aaa4ffc06ea66e344145f4918bcbef1f59fa6b3c13e3L84-R85): Updated the `CIRCULAR` variable to use the new `AUTO_DETECT_CIRCULAR` parameter in the `is_circular` function.