### PR TITLE
Amend output fasta headers to include origin fasta filename

### DIFF
--- a/mess/workflow/rules/processing/reads.smk
+++ b/mess/workflow/rules/processing/reads.smk
@@ -365,7 +365,18 @@ rule cat_fastqs:
         "Concatenating {wildcards.sample} reads : {params.head} ... "
     shell:
         """
-        find {params.dir} -name "{params.name}" | xargs cat > {output}
+        (
+        for f in {input}; do
+            # Get fasta name from path
+            fasta=$(basename $(dirname $f))
+            
+            # Process headers with awk and output directly
+            zcat $f | awk -v fasta=$fasta '
+            NR % 4 == 1 {{ print "@" fasta ":" substr($0, 2); next; }}
+            {{ print $0; }}
+            '
+        done
+        ) | gzip > {output}
         """
 
 


### PR DESCRIPTION
This pull request includes an important change to the `rule cat_fastqs` in the `mess/workflow/rules/processing/reads.smk` file. The change improves the way FASTQ files are concatenated and processed by incorporating origin fasta file names in the headers if `--skip-shuffle` is specified.

Key changes:

* Improved FASTQ file concatenation:
  * Replaced the `find` and `xargs cat` command with a loop that processes each input file individually.
  * Added a step to extract the fasta name from the file path and process headers using `awk` to include the fasta name in the output.
  * Output is now compressed using `gzip` instead of being directly written to the output file.